### PR TITLE
CRC32 support

### DIFF
--- a/hash.inc
+++ b/hash.inc
@@ -33,6 +33,9 @@
 #define RIPEMD256_LENGTH 64
 #define RIPEMD320_LENGTH 80
 
+// CRC32
+native crc32(const key[]);
+
 // Hashing
 native sha256(const key[], hash[], len = sizeof(hash));
 native sha384(const key[], hash[], len = sizeof(hash)); 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,9 @@ PLUGIN_EXPORT void PLUGIN_CALL ProcessTick()
 
 AMX_NATIVE_INFO hash_natives[] =
 {
+	// CRC32
+	{"crc32", Native::crc32},
+
 	// Hashing
 	{"sha256", Native::sha256},
 	{"sha384", Native::sha384},

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -200,6 +200,15 @@ cell AMX_NATIVE_CALL Native::slow_equals(AMX *amx, cell *params)
 	return static_cast<cell>(diff == 0);
 }
 
+cell AMX_NATIVE_CALL Native::crc32(AMX *amx, cell *params)
+{
+	PARAM_CHECK(1, "crc32");
+
+	char *str = NULL;
+	amx_StrParam(amx, params[1], str);
+	return Utility::crc32(str ? str : "");
+}
+
 cell AMX_NATIVE_CALL Native::sha256(AMX *amx, cell *params)
 {
 	PARAM_CHECK(3, "sha256");

--- a/src/natives.h
+++ b/src/natives.h
@@ -23,6 +23,9 @@
 
 namespace Native
 {
+	// CRC32
+	cell AMX_NATIVE_CALL crc32(AMX *amx, cell *params);
+	
 	// Hashing
 	cell AMX_NATIVE_CALL sha256(AMX *amx, cell *params);
 	cell AMX_NATIVE_CALL sha384(AMX *amx, cell *params);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -26,6 +26,7 @@
 #include "cryptopp/pwdbased.h"
 #include "cryptopp/filters.h"
 #include "cryptopp/integer.h"
+#include "cryptopp/crc.h"
 
 #include "utility.h"
 
@@ -48,6 +49,17 @@ void Utility::hex_encode(string input, string &output)
 void Utility::hex_decode(string input, string &output)
 {
 	CryptoPP::StringSource(input, true, new CryptoPP::HexDecoder(new CryptoPP::StringSink(output)));
+}
+
+cell Utility::crc32(string input)
+{
+	CryptoPP::CRC32 crc32;
+	crc32.Update(reinterpret_cast<const byte*>(input.c_str()), input.length());
+
+	cell result;
+	crc32.Final(reinterpret_cast<byte*>(&result));
+
+	return result;
 }
 
 void Utility::sha256(string input, string &output)

--- a/src/utility.h
+++ b/src/utility.h
@@ -39,6 +39,7 @@ typedef struct
 
 namespace Utility
 {
+	cell crc32(string input);
 	void sha256(string input, string &output);
 	void sha384(string input, string &output);
 	void sha512(string input, string &output);


### PR DESCRIPTION
Useful function for calculating 32bit checksum:
```pawn
// 'Hello, world!': 0xEBE6C6E6
printf("[debug] 'Hello, world!': 0x%08x", crc32("Hello, world!"));

// 'The quick brown fox jumps over the lazy dog': 0x414FA339
printf("[debug] 'The quick brown fox jumps over the lazy dog': 0x%08x", crc32("The quick brown fox jumps over the lazy dog"));

// '': 0x00000000
printf("[debug] '': 0x%08x", crc32(""));
```