### PR TITLE
Fix build 32-bit for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ obj/
 *.lib
 *.pdb
 *.idb
+
+bin/
+lib/
+src/cryptopp/*.a
+src/cryptopp/*.o

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ Hash Plugin for SA-MP
 =====================
 
 Full documentation as well as installation & compiling notes can be found on the SA-MP forums.
+
+
+Build from source
+=================
+
+### Ubuntu 18.04 / Debian 9
+`# apt-get install gcc g++ gcc-multilib g++-multilib`
+### Fedora 29
+`# dnf install gcc.i686 gcc-c++.i686 glibc-devel.i686`

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ hash:
 	$(GPP) -m32 -O2 -fshort-wchar -shared -o $(OUTPUT) *.o $(LIBRARIES)
 	
 cryptolib:
-	$(MAKE) -C $(CRYPTOPP_SRC_DIR) static
+	CXXFLAGS="-DNDEBUG -m32 -g2 -O3 -fPIC" $(MAKE) -C $(CRYPTOPP_SRC_DIR) static
 	mkdir -p lib
 	cp $(CRYPTOPP_SRC_DIR)/libcryptopp.a ./lib
 	

--- a/src/callback.cpp
+++ b/src/callback.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <cstring>
+#include <functional>
 #include "callback.h"
 #include "plugin.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdlib>
+#include <functional>
 
 #include "plugin.h"
 #include "callback.h"

--- a/src/main.h
+++ b/src/main.h
@@ -21,7 +21,7 @@
 
 #include <SDK/plugin.h>
 
-#define PLUGIN_VERSION "0.0.4"
+#define PLUGIN_VERSION "0.0.5"
 #define PARAM_CHECK(c, n) \
 	if(params[0] != (c * 4)) \
 	{ \


### PR DESCRIPTION
I've added a flag to build 32-bit .so file for Linux. The build was success, but not tested yet if something bad happen. And add missing includes too (since rewrite to C++17 standard).